### PR TITLE
add support for http.Post

### DIFF
--- a/httputil/httputil.go
+++ b/httputil/httputil.go
@@ -1,6 +1,7 @@
 package httputil
 
 import (
+	"io"
 	"net/http"
 
 	"github.com/syumai/tinyutil/internal/net_http"
@@ -20,8 +21,21 @@ func (c *Client) Get(url string) (resp *http.Response, err error) {
 	return c.Do(req)
 }
 
+func (c *Client) Post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
+	req, err := http.NewRequest("POST", url, body)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", contentType)
+	return c.Do(req)
+}
+
 var DefaultClient = &Client{}
 
 func Get(url string) (resp *http.Response, err error) {
 	return DefaultClient.Get(url)
+}
+
+func Post(url, contentType string, body io.Reader) (resp *http.Response, err error) {
+	return DefaultClient.Post(url, contentType, body)
 }


### PR DESCRIPTION
Add support for http.Post by copying the following code.

https://github.com/golang/go/blob/release-branch.go1.19/src/net/http/client.go#L824-L826


At least the following code worked with TinyGo 0.25.

```go
		body := fmt.Sprintf(`{"button": "button1", "keys": "tiny post", "keycodes": []}`)
		res, err := httputil.Post("http://192.168.1.111", "application/json", strings.NewReader(body))
```